### PR TITLE
[FIX] Python 3 compatibility

### DIFF
--- a/repubcal.py
+++ b/repubcal.py
@@ -464,7 +464,7 @@ def d_to_french_revolutionary(date):
     rdate = {}
     rdate['an'], equinoxe = annee_de_la_revolution(date)
     nb_day_in_year = (date - equinoxe).days
-    rdate['mois'] = nb_day_in_year / 30
+    rdate['mois'] = nb_day_in_year // 30
     rdate['jour'] = nb_day_in_year % 30
     rdate['decade'] = (rdate['jour'] // 10) + 1 + 3*rdate['mois']
     return rdate


### PR DESCRIPTION
Fixes int division in Python 2 that becomes float in Python 3 and breaks month calculation.

Tested on Python 3.8.1 and Python 2.7.17.